### PR TITLE
remove 'current' in return for policy coverage period

### DIFF
--- a/libs/carrier-portal/ui/src/lib/member-policy/member-policy.component.html
+++ b/libs/carrier-portal/ui/src/lib/member-policy/member-policy.component.html
@@ -45,7 +45,7 @@
           <td>{{ t('relationships.' + enrollee.relationship) | titlecase }}</td>
           <td>
             {{ enrollee.coverage_start | date : 'M/d/yy' }}
-            - {{ (enrollee.coverage_end | date : 'M/d/yy') ?? 'Current' }}
+            - {{ (enrollee.coverage_end | date : 'M/d/yy') ?? '' }}
           </td>
           <td>{{ enrollee.carrier_member_id }}</td>
           <td>{{ enrollee.carrier_policy_id }}</td>


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated the display behavior for the coverage end date in the enrollment group information. Previously, if the coverage end date was not available, it would default to "Current". With this update, an unavailable coverage end date will now be displayed as an empty string, providing a more accurate representation of the data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->