### PR TITLE
update app title and ME logo capitalization

### DIFF
--- a/apps/console/src/index.html
+++ b/apps/console/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Carrier Portal</title>
+    <title>CoverME.gov Carrier Portal</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.svg" />

--- a/libs/console/shell/src/lib/shell/shell.component.scss
+++ b/libs/console/shell/src/lib/shell/shell.component.scss
@@ -25,7 +25,6 @@
     padding: 1.5rem 1.5rem 0 1.5rem;
     font-size: 1.25rem;
     font-weight: 800;
-    text-transform: uppercase;
   }
 }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Style: Updated the title in `index.html` to "CoverME.gov Carrier Portal" for better brand recognition and SEO.
- Style: Removed the `text-transform: uppercase;` property from a CSS rule in `shell.component.scss` to improve text readability across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->