### PR TITLE
Upgrade keycloak to 25 in preprod.

### DIFF
--- a/apps/console/src/app/keycloak-config.ts
+++ b/apps/console/src/app/keycloak-config.ts
@@ -11,7 +11,7 @@ export const keycloakConfiguration: KeycloakConfig[] = [
     host: 'preprod-console.cme.openhbx.org',
     clientId: 'openid',
     realm: 'preprod',
-    url: 'https://preprod-sso.cme.openhbx.org/auth',
+    url: 'https://preprod-sso.cme.openhbx.org',
   },
   {
     host: 'carrier-portal.coverme.gov',


### PR DESCRIPTION
Testing of the keycloak 25 upgrade in preprod.  Only requires a change in configuration files, but will be ready to roll back if there are issues.

https://www.pivotaltracker.com/story/show/188024298